### PR TITLE
This modification permit to use optional parameter "mode" in fonction set_power().

### DIFF
--- a/index.js
+++ b/index.js
@@ -357,11 +357,12 @@ Yeelight.prototype.set_bright = function (brightness, effect, duration){
 *              <li>"off" means turn off the smart LED. 
  * @param {String} effect   [description]
  * @param {Number} duration [description]
+ * @param {Number} mode [description]
  * @returns {Promise} see {@link Yeelight#command} 
  */
 Yeelight.prototype.set_power = function (power, effect, duration){
   power =  ~[ 1, true, '1','on' ].indexOf(power) ? 'on' : 'off';
-  return this.command('set_power', [ power, effect || 'smooth', duration || 500  ]);
+  return this.command('set_power', [ power, effect || 'smooth', duration || 500  ], mode || 0);
 };
 
 /**

--- a/index.js
+++ b/index.js
@@ -362,7 +362,7 @@ Yeelight.prototype.set_bright = function (brightness, effect, duration){
  */
 Yeelight.prototype.set_power = function (power, effect, duration){
   power =  ~[ 1, true, '1','on' ].indexOf(power) ? 'on' : 'off';
-  return this.command('set_power', [ power, effect || 'smooth', duration || 500  ], mode || 0);
+  return this.command('set_power', [ power, effect || 'smooth', duration || 500 , mode || 0 ]);
 };
 
 /**


### PR DESCRIPTION
This modification permit to use optional parameter **mode** in fonction **set_power()**.
it is useful in certain case (and i need it ;) )

 0: Normal turn on operation (default value)
 1: Turn on and switch to CT mode.
 2: Turn on and switch to RGB mode.
 3: Turn on and switch to HSV mode.
 4: Turn on and switch to color flow mode.
 5: Turn on and switch to Night light mode. (Ceiling light only).

See documentation on page 13: https://www.yeelight.com/download/Yeelight_Inter-Operation_Spec.pdf