### PR TITLE
Fix discover

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ Yeelight.discover = function(port, callback){
     callback = port; port = 1982;
   }
   var yeelights = [];
-  var discover = ssdp({ port: port || 1982 });
+  var discover = new ssdp({ port: port || 1982 });
   discover.on('response', function(response){
     console.debug(response.headers);
     const { 
@@ -104,6 +104,7 @@ Yeelight.discover = function(port, callback){
       yeelight.supports = support && support.split(' ') || [];
       yeelight.on('connect', function(){
         callback.call(discover, this, response);
+	discover.close()
       });
     };
   });


### PR DESCRIPTION
Fixes issue where discovery timeout as no new ssdp object is created which results in `Network timeout, Yeelight not response`.
Might fix #18 
Also fixes issue where multiple discovery attempts are made results in `Network timeout, Yeelight not response` as the old ssdp connection is never closed which results with the new ssdp connection can't bind, which later results in timeout for the response.
This started showing for me after updateing with npm to latest yeelight after trying to upgrade ssdp2 in https://github.com/jNullj/light-on-tray/pull/58